### PR TITLE
Add exercise loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,3 +144,14 @@ alembic upgrade head
 3. Commit your changes
 4. Push to the branch
 5. Create a Pull Request 
+## Loading Built-in Exercises
+
+Use `load_exercises.py` to read the predefined exercise YAML files.
+The script relies on PyYAML, so make sure the dependencies are installed:
+
+```bash
+python load_exercises.py
+```
+
+This will print the number of exercises parsed from the `exercises/` folder.
+

--- a/load_exercises.py
+++ b/load_exercises.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+from typing import Dict
+
+import yaml
+
+
+def load_exercises(directory: str = "exercises") -> Dict[str, dict]:
+    """Load all exercise YAML files into a mapping by exercise name.
+
+    Each exercise dictionary contains ``name``, ``movement`` and ``muscles``
+    keys exactly as specified in the YAML files.
+    """
+    result: Dict[str, dict] = {}
+    for yaml_file in Path(directory).rglob("*.yaml"):
+        with yaml_file.open() as f:
+            data = yaml.safe_load(f) or []
+            for exercise in data:
+                if isinstance(exercise, dict) and "name" in exercise:
+                    result[exercise["name"]] = exercise
+    return result
+
+
+if __name__ == "__main__":
+    loaded = load_exercises()
+    print(f"Loaded {len(loaded)} exercises")
+    for name in list(loaded)[:5]:
+        print("-", name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ pytest-cov>=4.1.0
 black>=23.7.0
 isort>=5.12.0
 mypy>=1.5.0
+PyYAML>=6.0
 
 
 


### PR DESCRIPTION
## Summary
- write a small loader for exercises YAML data
- document how to use the loader
- use PyYAML instead of a simple parser

## Testing
- `pytest -q`
- `python load_exercises.py | head -n 10`


------
https://chatgpt.com/codex/tasks/task_e_684c1d49ec9083308eeae01cf3293bce