### PR TITLE
Add FastAPI workout recommendation endpoints

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from fastapi import APIRouter
+
+from app.models import User
+from app.recovery import update_recovery
+from app.recommendation import recommend_workout
+from workout import Workout
+
+router = APIRouter()
+
+# in-memory user storage
+USERS: Dict[str, User] = {}
+
+
+def get_user(user_id: str) -> User:
+    if user_id not in USERS:
+        USERS[user_id] = User(id=user_id, name=user_id)
+    return USERS[user_id]
+
+
+@router.post("/users/{user_id}/workouts")
+def log_workout(user_id: str, workout: Workout):
+    user = get_user(user_id)
+    timestamp = datetime.combine(workout.date, datetime.min.time())
+    update_recovery(user, workout.work_done, timestamp=timestamp)
+    return {"status": "logged", "recovery": user.recovery.scores}
+
+
+@router.get("/users/{user_id}/recovery")
+def recovery_status(user_id: str):
+    user = get_user(user_id)
+    user.recovery.decay(datetime.utcnow())
+    return user.recovery.scores
+
+
+@router.get("/users/{user_id}/recommendations")
+def workout_recommendations(user_id: str):
+    user = get_user(user_id)
+    recs = recommend_workout(user)
+    return {"recommendations": recs}

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,12 @@
+from fastapi import FastAPI
+
+from app.api import router
+
+app = FastAPI()
+app.include_router(router)
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/app/recommendation.py
+++ b/app/recommendation.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Union
+
+from core import Movement
+from app.models import User
+from load_exercises import load_exercises
+
+# load exercise library once
+EXERCISES: Dict[str, dict] = load_exercises()
+
+
+def recommend_workout(
+    user: User,
+    *,
+    max_exercises: int = 5,
+    fatigue_threshold: float = 100.0,
+) -> Union[List[str], str]:
+    """Return a list of recommended exercise names or 'rest'."""
+    # ensure recovery decay applied to current time
+    user.recovery.decay(datetime.utcnow())
+
+    # determine which movement patterns are too fatigued
+    fatigued = {
+        m
+        for m, score in user.recovery.scores.items()
+        if score > fatigue_threshold
+    }
+
+    # gather allowed movements in order of least fatigue
+    movements = sorted(
+        [(m, user.recovery.scores.get(m, 0.0)) for m in Movement],
+        key=lambda t: t[1],
+    )
+    allowed_movements = [m for m, score in movements if m not in fatigued]
+
+    if not allowed_movements:
+        return "rest"
+
+    # collect exercises from permitted movements
+    candidates = [
+        ex["name"]
+        for ex in EXERCISES.values()
+        if Movement(ex["movement"]) in allowed_movements
+    ]
+    return candidates[:max_exercises]


### PR DESCRIPTION
## Summary
- create recommendation helper
- expose workout logging and recommendation API endpoints
- add FastAPI entrypoint

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c33a92a788330b419d8e79f96788e