### PR TITLE
Extend fatigue tracking to muscles and quality

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,21 +1,36 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
-from typing import TYPE_CHECKING
 from pydantic import BaseModel
-
 
 if TYPE_CHECKING:
     from app.recovery import WorkoutRecord
-from core import Movement, WorkDone, aggregate_workload
+
+from collections import defaultdict
+
+from core import (
+    CardioSession,
+    Exercise,
+    Movement,
+    Muscle,
+    MuscleQuality,
+    MuscleUsage,
+    WeightedSet,
+    WorkDone,
+    aggregate_muscle_workload,
+    aggregate_workload,
+)
+from load_exercises import load_exercises
 
 
 class RecoveryState(BaseModel):
     """Stores fatigue levels for each movement pattern."""
 
     scores: Dict[Movement, float] = {}
+    muscle_scores: Dict[Muscle, float] = {}
+    quality_scores: Dict[MuscleQuality, float] = {}
     last_update: Optional[datetime] = None
 
     def decay(self, now: datetime, half_life_hours: float = 48) -> None:
@@ -27,6 +42,10 @@ class RecoveryState(BaseModel):
         factor = 0.5 ** (hours / half_life_hours)
         for m in list(self.scores):
             self.scores[m] *= factor
+        for mus in list(self.muscle_scores):
+            self.muscle_scores[mus] *= factor
+        for q in list(self.quality_scores):
+            self.quality_scores[q] *= factor
         self.last_update = now
 
     def apply_workout(self, work: List[WorkDone], now: datetime) -> None:
@@ -36,13 +55,47 @@ class RecoveryState(BaseModel):
         for m, amount in totals.items():
             self.scores[m] = self.scores.get(m, 0.0) + amount
 
+        raw_ex = load_exercises()
+        exercises: Dict[str, Exercise] = {}
+        for n, d in raw_ex.items():
+            muscles = []
+            for md in d.get("muscles", []):
+                try:
+                    muscles.append(
+                        MuscleUsage(
+                            muscle=Muscle(md["muscle"]),
+                            amount=float(md["amount"]),
+                            quality=MuscleQuality(md["quality"]),
+                        )
+                    )
+                except Exception:
+                    continue
+            try:
+                exercises[n] = Exercise(
+                    name=n, movement=Movement(d["movement"]), muscles=muscles
+                )
+            except Exception:
+                continue
+
+        muscle_totals = aggregate_muscle_workload(work, exercises)
+        for mus, amt in muscle_totals.items():
+            self.muscle_scores[mus] = self.muscle_scores.get(mus, 0.0) + amt
+
+        quality_totals: Dict[MuscleQuality, float] = defaultdict(float)
+        for item in work:
+            if isinstance(item, (WeightedSet, CardioSession)):
+                ex = exercises.get(item.exercise_name)
+                if not ex:
+                    continue
+                for usage in ex.muscles:
+                    quality_totals[usage.quality] += item.workload * usage.amount
+
+        for q, amt in quality_totals.items():
+            self.quality_scores[q] = self.quality_scores.get(q, 0.0) + amt
+
 
 class User(BaseModel):
     id: str
     name: str
     recovery: RecoveryState = RecoveryState()
-    workouts: List['WorkoutRecord'] = []
-
-
-
-
+    workouts: List["WorkoutRecord"] = []

--- a/app/recommendation.py
+++ b/app/recommendation.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta
-from typing import Dict, List, Union, DefaultDict
-
 from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import DefaultDict, Dict, List, Union
 
-from core import Movement, WeightedSet, PercievedExertion
 from app.models import User
+from core import (
+    CardioSession,
+    Exercise,
+    Movement,
+    Muscle,
+    MuscleQuality,
+    MuscleUsage,
+    PercievedExertion,
+    WeightedSet,
+)
 from load_exercises import load_exercises
 
 # load exercise library once
@@ -31,9 +39,7 @@ def recommend_workout(
 
     # determine which movement patterns are too fatigued
     fatigued = {
-        m
-        for m, score in user.recovery.scores.items()
-        if score > fatigue_threshold
+        m for m, score in user.recovery.scores.items() if score > fatigue_threshold
     }
 
     # gather allowed movements in order of least fatigue
@@ -48,23 +54,19 @@ def recommend_workout(
 
     # build basic stats from recent workouts (last 7 days)
     cutoff = datetime.utcnow() - timedelta(days=7)
-    history: DefaultDict[str, Dict[str, float]] = defaultdict(lambda: {
-        "sets": 0,
-        "reps": 0,
-        "intensity": 0.0,
-        "count": 0,
-    })
+    history: DefaultDict[str, Dict[str, float]] = defaultdict(
+        lambda: {
+            "workload": 0.0,
+            "count": 0,
+        }
+    )
     for record in user.workouts:
         if record.date < cutoff:
             continue
         for item in record.work_done:
-            if isinstance(item, WeightedSet):
+            if isinstance(item, (WeightedSet, CardioSession)):
                 stats = history[item.exercise_name]
-                stats["sets"] += 1
-                reps = item.ac_reps if item.ac_reps else item.ex_reps
-                stats["reps"] += reps
-                intensity = int(item.pe.value) / int(PercievedExertion.MAX.value)
-                stats["intensity"] += intensity
+                stats["workload"] += item.workload
                 stats["count"] += 1
 
     # score candidate exercises
@@ -74,15 +76,50 @@ def recommend_workout(
         if movement not in allowed_movements:
             continue
 
-        base = 1.0 / (1.0 + user.recovery.scores.get(movement, 0.0))
+        muscles = []
+        for md in ex.get("muscles", []):
+            try:
+                muscles.append(
+                    MuscleUsage(
+                        muscle=Muscle(md["muscle"]),
+                        amount=float(md["amount"]),
+                        quality=MuscleQuality(md["quality"]),
+                    )
+                )
+            except Exception:
+                continue
+        try:
+            ex_obj = Exercise(
+                name=ex["name"], movement=Movement(ex["movement"]), muscles=muscles
+            )
+        except Exception:
+            continue
+
+        # base factors from recovery
+        base = 1.0 / (1.0 + user.recovery.scores.get(movement, 0.0) / 100.0)
+
+        muscle_fatigues = [
+            user.recovery.muscle_scores.get(u.muscle, 0.0) for u in ex_obj.muscles
+        ]
+        quality_fatigues = [
+            user.recovery.quality_scores.get(u.quality, 0.0) for u in ex_obj.muscles
+        ]
+
+        muscle_factor = 1.0 / (
+            1.0 + (max(muscle_fatigues) if muscle_fatigues else 0.0) / 100.0
+        )
+        quality_factor = 1.0 / (
+            1.0 + (max(quality_fatigues) if quality_fatigues else 0.0) / 100.0
+        )
+
         stats = history.get(ex["name"])
         if stats and stats["count"]:
-            avg_int = stats["intensity"] / stats["count"]
-            avg_reps = stats["reps"] / stats["count"]
-            intensity_factor = 1.0 / (1.0 + avg_int * avg_reps)
+            avg_work = stats["workload"] / stats["count"]
+            intensity_factor = 1.0 / (1.0 + (avg_work / 100.0))
         else:
             intensity_factor = 1.0
-        score = base * intensity_factor
+
+        score = base * muscle_factor * quality_factor * intensity_factor
         scored.append((score, ex["name"]))
 
     scored.sort(key=lambda t: t[0], reverse=True)

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,9 +1,9 @@
 import datetime as dt
 
 from app.models import User
-from app.recovery import update_recovery
 from app.recommendation import recommend_workout
-from core import WeightedSet, Movement, PercievedExertion
+from app.recovery import update_recovery
+from core import CardioSession, Movement, PercievedExertion, WeightedSet
 
 
 def test_recommendation_ranks_by_intensity():
@@ -32,3 +32,35 @@ def test_recommendation_ranks_by_intensity():
     assert "Dumbbell Bench" in recs
     assert recs.index("Dumbbell Row") < recs.index("Dumbbell Bench")
 
+
+def test_recommendation_filters_fatigued_muscles():
+    user = User(id="u1", name="User")
+    heavy = WeightedSet(
+        exercise_name="Dumbbell Bench",
+        pattern=Movement.UPPER_PUSH,
+        ex_weight=50,
+        ac_weight=50,
+        ex_reps=10,
+        ac_reps=10,
+        pe=PercievedExertion.MAX,
+    )
+    update_recovery(user, [heavy], timestamp=dt.datetime.utcnow())
+    recs = recommend_workout(user, max_exercises=25)
+    assert "Dumbbell Bench" not in recs
+
+
+def test_recommendation_ranks_cardio_history():
+    user = User(id="u1", name="User")
+    run = CardioSession(
+        exercise_name="Run",
+        ex_duration=30,
+        ac_duration=30,
+        ex_heart_rate=170,
+        ac_heart_rate=170,
+        pe=PercievedExertion.HIGH,
+    )
+    update_recovery(user, [run], timestamp=dt.datetime.utcnow())
+    recs = recommend_workout(user, max_exercises=25)
+    assert "Jump Rope" in recs
+    assert "Run" in recs
+    assert recs.index("Jump Rope") < recs.index("Run")


### PR DESCRIPTION
## Summary
- track fatigue per muscle and per muscle quality
- include muscle and quality fatigue in recommendation ranking
- account for cardio history when ranking exercises
- add tests for cardio ranking

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c4aa4d5848330b911c10124c4dfa7