### PR TITLE
Add snapshot API

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter
 
 from app.models import User
 from app.recovery import update_recovery
-from app.recommendation import recommend_workout
+from app.recommendation import recommend_workout, recommend_movements
 from workout import Workout
 
 router = APIRouter()
@@ -42,3 +42,11 @@ def workout_recommendations(user_id: str):
     user = get_user(user_id)
     recs = recommend_workout(user)
     return {"recommendations": recs}
+
+
+@router.get("/users/{user_id}/snapshot")
+def recovery_snapshot(user_id: str):
+    """Return recovery scores and suggested movement patterns."""
+    user = get_user(user_id)
+    movements = [m.value for m in recommend_movements(user)]
+    return {"recovery": user.recovery.scores, "recommended_movements": movements}

--- a/app/recommendation.py
+++ b/app/recommendation.py
@@ -124,3 +124,19 @@ def recommend_workout(
 
     scored.sort(key=lambda t: t[0], reverse=True)
     return [name for _, name in scored[:max_exercises]] if scored else "rest"
+
+
+def recommend_movements(
+    user: User, *, fatigue_threshold: float = 100.0
+) -> List[Movement]:
+    """Return movement patterns suitable for the next session.
+
+    The movements are sorted from least to most fatigued and filtered using the
+    provided ``fatigue_threshold``.
+    """
+    user.recovery.decay(datetime.utcnow())
+    scored = sorted(
+        [(m, user.recovery.scores.get(m, 0.0)) for m in Movement],
+        key=lambda t: t[1],
+    )
+    return [m for m, score in scored if score <= fatigue_threshold]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,12 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_snapshot_endpoint():
+    client = TestClient(app)
+    resp = client.get("/users/test_user/snapshot")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "recovery" in data
+    assert "recommended_movements" in data
+    assert isinstance(data["recommended_movements"], list)

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,7 +1,7 @@
 import datetime as dt
 
 from app.models import User
-from app.recommendation import recommend_workout
+from app.recommendation import recommend_workout, recommend_movements
 from app.recovery import update_recovery
 from core import CardioSession, Movement, PercievedExertion, WeightedSet
 
@@ -64,3 +64,9 @@ def test_recommendation_ranks_cardio_history():
     assert "Jump Rope" in recs
     assert "Run" in recs
     assert recs.index("Jump Rope") < recs.index("Run")
+
+
+def test_recommend_movements_returns_all_when_fresh():
+    user = User(id="u1", name="User")
+    moves = recommend_movements(user)
+    assert set(m.value for m in moves) == set(m.value for m in Movement)


### PR DESCRIPTION
## Summary
- add new endpoint `/users/{user_id}/snapshot`
- implement `recommend_movements` helper
- test snapshot endpoint and movement recommendation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c58d751d08330886eca98bb5bd68d