### PR TITLE
Ensure recommend_workout returns full plans

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter
 
 from app.models import User
 from app.recovery import update_recovery
-from app.recommendation import recommend_workout
+from app.recommendation import recommend_workout, recommend_movements
 from workout import Workout
 
 router = APIRouter()


### PR DESCRIPTION
## Summary
- build workout plan using `_build_plan`
- expose `recommend_movements` from API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c655ea83883308077e53b0fc465ab