### PR TITLE
Improve workout history integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ pip install -r requirements.txt
 
 ## Running the API
 
-The API is defined in `app.main`. When the server starts it loads all CSV files in the `_Workouts/` directory for a default user named **Josh**. Exercises are populated from the YAML files in `exercises/`.
+The API is defined in `app.main`. When the server starts it loads all CSV files in the `_Workouts/` directory for a default user named **Josh**. The helper `load_user_history` parses these files and updates Josh's recovery state so recommendations immediately reflect his recent training. Exercises are populated from the YAML files in `exercises/`.
 
 Start the server with:
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,14 @@
 from fastapi import FastAPI
 
 from app.api import router
-from workout import load_workout_data
+from workout import load_user_history
 
 
 app = FastAPI()
 
-# Preload the sample workout CSV files for a default user
-load_workout_data(user_id="Josh")
+# Preload the sample workout CSV files for a default user and
+# apply them to the in-memory state so recommendations work
+load_user_history(user_id="Josh")
 
 app.include_router(router)
 

--- a/workout.py
+++ b/workout.py
@@ -149,6 +149,21 @@ def load_workout_data(directory="_Workouts", user_id: str = "default"):
     return workout_data
 
 
+def load_user_history(user_id: str, directory: str = "_Workouts") -> Dict[str, Workout]:
+    """Load workouts from ``directory`` and apply them to a User."""
+
+    from datetime import datetime, time
+    from app.api import get_user
+    from app.recovery import update_recovery
+
+    data = load_workout_data(directory=directory, user_id=user_id)
+    user = get_user(user_id)
+    for workout in sorted(data.values(), key=lambda w: w.date):
+        ts = datetime.combine(workout.date, time.min)
+        update_recovery(user, workout.work_done, timestamp=ts)
+    return data
+
+
 workouts = load_workout_data()
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- load workout history into Josh's recovery state at startup
- compute training plans from recent sessions for better recommendations
- expose helper `load_user_history`
- document auto-loading behaviour in README

## Testing
- `pip install -q httpx==0.24.1`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6a51250883309796dba3897ac3f6