### PR TITLE
Add reasoning to workout recommendations

### DIFF
--- a/app/recommendation.py
+++ b/app/recommendation.py
@@ -202,6 +202,34 @@ def recommend_workout(
                 plan["weight"] = round(stats["weight_total"] / stats["count"], 1)
                 plan["reps"] = int(round(stats["reps_total"] / stats["count"]))
 
+        fatigue = user.recovery.scores.get(movement, 0.0)
+        if stats and stats["count"]:
+            sessions = stats["count"]
+            if movement == Movement.CARDIO:
+                plan["reason"] = (
+                    f"This cardio exercise was selected because your {movement.value.replace('_', ' ')} pattern "
+                    f"is relatively recovered (fatigue {fatigue:.1f}). Duration {plan['duration']} min at "
+                    f"{plan['heart_rate']} bpm reflects the average of your last {sessions} session(s)."
+                )
+            else:
+                plan["reason"] = (
+                    f"Your {movement.value.replace('_', ' ')} pattern is relatively recovered (fatigue {fatigue:.1f}). "
+                    f"Suggested {plan['reps']} reps at {plan['weight']} weight is based on the average of your "
+                    f"last {sessions} session(s)."
+                )
+        else:
+            if movement == Movement.CARDIO:
+                plan["reason"] = (
+                    f"This cardio exercise was selected because your {movement.value.replace('_', ' ')} pattern "
+                    f"is relatively recovered (fatigue {fatigue:.1f}). No recent history found so default "
+                    f"duration {plan['duration']} min and heart rate {plan['heart_rate']} bpm are suggested."
+                )
+            else:
+                plan["reason"] = (
+                    f"Your {movement.value.replace('_', ' ')} pattern is relatively recovered (fatigue {fatigue:.1f}). "
+                    f"No recent history found so default {plan['weight']} weight for {plan['reps']} reps is suggested."
+                )
+
         score = base * muscle_factor * quality_factor * intensity_factor
         scored.append((score, plan))
 

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -38,6 +38,8 @@ def test_recommendation_ranks_by_intensity():
     assert row["reps"] == 5
     assert bench["weight"] == 20
     assert bench["reps"] == 5
+    assert "reason" in row and isinstance(row["reason"], str)
+    assert "reason" in bench and isinstance(bench["reason"], str)
 
 
 def test_recommendation_filters_fatigued_muscles():
@@ -55,6 +57,9 @@ def test_recommendation_filters_fatigued_muscles():
     recs = recommend_workout(user, max_exercises=25)
     names = [r["name"] for r in recs] if isinstance(recs, list) else []
     assert "Dumbbell Bench" not in names
+    if isinstance(recs, list):
+        for item in recs:
+            assert "reason" in item and isinstance(item["reason"], str)
 
 
 def test_recommendation_ranks_cardio_history():
@@ -76,3 +81,5 @@ def test_recommendation_ranks_cardio_history():
     run_rec = next(r for r in recs if r["name"] == "Run")
     assert run_rec["duration"] == 30
     assert run_rec["heart_rate"] == 170
+    for item in recs:
+        assert "reason" in item and isinstance(item["reason"], str)


### PR DESCRIPTION
## Summary
- enrich exercise recommendations with a `reason` field describing why each exercise, weight, reps, duration or heart rate was chosen
- ensure tests expect this new explanatory field

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c6dfcb17c8330800cacf814e268ee