### PR TITLE
Add user setup endpoint and bodyweight option

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -6,6 +6,8 @@ from typing import Dict
 from fastapi import APIRouter
 
 from app.models import User
+from core import DEFAULT_BODYWEIGHT
+from pydantic import BaseModel
 from app.recovery import update_recovery
 from app.recommendation import recommend_workout, recommend_movements
 from workout import Workout
@@ -16,9 +18,26 @@ router = APIRouter()
 USERS: Dict[str, User] = {}
 
 
+class UserCreate(BaseModel):
+    name: str | None = None
+    bodyweight: float | None = None
+
+
 def get_user(user_id: str) -> User:
     if user_id not in USERS:
         USERS[user_id] = User(id=user_id, name=user_id)
+    return USERS[user_id]
+
+
+@router.post("/users/{user_id}")
+def create_user(user_id: str, data: UserCreate):
+    if user_id in USERS:
+        return USERS[user_id]
+    USERS[user_id] = User(
+        id=user_id,
+        name=data.name or user_id,
+        default_bodyweight=data.bodyweight or DEFAULT_BODYWEIGHT,
+    )
     return USERS[user_id]
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,8 +7,9 @@ from workout import load_user_history
 app = FastAPI()
 
 # Preload the sample workout CSV files for a default user and
-# apply them to the in-memory state so recommendations work
-load_user_history(user_id="Josh")
+# apply them to the in-memory state so recommendations work.
+# Josh is created via ``get_user`` inside ``load_user_history``.
+load_user_history(user_id="Josh", bodyweight=190)
 
 app.include_router(router)
 

--- a/workout.py
+++ b/workout.py
@@ -160,7 +160,12 @@ def load_workout_data(
     return workout_data
 
 
-def load_user_history(user_id: str, directory: str = "_Workouts") -> Dict[str, Workout]:
+def load_user_history(
+    user_id: str,
+    directory: str = "_Workouts",
+    *,
+    bodyweight: float | None = None,
+) -> Dict[str, Workout]:
     """Load workouts from ``directory`` and apply them to a User."""
 
     from datetime import datetime, time
@@ -168,6 +173,8 @@ def load_user_history(user_id: str, directory: str = "_Workouts") -> Dict[str, W
     from app.recovery import update_recovery
 
     user = get_user(user_id)
+    if bodyweight is not None:
+        user.default_bodyweight = bodyweight
     data = load_workout_data(
         directory=directory, user_id=user_id, bodyweight=user.default_bodyweight
     )


### PR DESCRIPTION
## Summary
- expose new `create_user` endpoint for customizing user info
- let `load_user_history` set a user's default bodyweight
- preload Josh with 190lb bodyweight

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8c466d208330ab2add2408b55985