### PR TITLE
Add experience based fatigue targets and weekly schedule

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict, List, Optional
+from enum import Enum
 
 from pydantic import BaseModel
 
@@ -24,6 +25,12 @@ from core import (
     aggregate_workload,
 )
 from load_exercises import load_exercises
+
+
+class ExperienceLevel(str, Enum):
+    BEGINNER = "beginner"
+    INTERMEDIATE = "intermediate"
+    ADVANCED = "advanced"
 
 
 class RecoveryState(BaseModel):
@@ -98,6 +105,9 @@ class RecoveryState(BaseModel):
 class User(BaseModel):
     id: str
     name: str
+    experience: ExperienceLevel = ExperienceLevel.BEGINNER
+    allowed_movements: List[Movement] = list(Movement)
+    workouts_per_week: Optional[int] = None
     default_bodyweight: float = DEFAULT_BODYWEIGHT
     recovery: RecoveryState = RecoveryState()
     workouts: List["WorkoutRecord"] = []

--- a/tests/test_recommendation.py
+++ b/tests/test_recommendation.py
@@ -1,7 +1,12 @@
 import datetime as dt
 
 from app.models import User
-from app.recommendation import recommend_workout, recommend_movements
+from app.recommendation import (
+    recommend_workout,
+    recommend_movements,
+    weekly_fatigue_targets,
+    suggest_weekly_movements,
+)
 from app.recovery import update_recovery
 from core import CardioSession, Movement, PercievedExertion, WeightedSet
 
@@ -63,3 +68,23 @@ def test_recommendation_cardio_removed_when_fatigued():
     recs = recommend_workout(user, max_exercises=10)
     names = [r["name"] for r in recs] if isinstance(recs, list) else []
     assert "Run" not in names
+
+
+def test_weekly_targets_scale_with_experience():
+    user = User(id="u1", name="User")
+    beginner = weekly_fatigue_targets(user)
+    user.experience = user.experience.__class__.ADVANCED
+    advanced = weekly_fatigue_targets(user)
+    assert advanced[Movement.UPPER_PUSH] > beginner[Movement.UPPER_PUSH]
+
+
+def test_weekly_schedule_respects_allowed_movements():
+    user = User(
+        id="u2",
+        name="User",
+        allowed_movements=[Movement.CARDIO, Movement.UPPER_PULL],
+    )
+    schedule = suggest_weekly_movements(user, workouts_per_week=3)
+    for day_moves in schedule.values():
+        for m in day_moves:
+            assert m in user.allowed_movements


### PR DESCRIPTION
## Summary
- introduce `ExperienceLevel` enum and user settings
- compute weekly fatigue targets scaled by experience
- allow per-user allowed movements
- suggest weekly movements based on training frequency
- adjust recommendations to use new targets
- add unit tests for new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c8f788924833092efb8a290925815