### PR TITLE
Implement db helpers

### DIFF
--- a/app/db/user.py
+++ b/app/db/user.py
@@ -1,0 +1,33 @@
+from uuid import UUID
+from typing import Optional
+
+from tortoise.exceptions import DoesNotExist
+
+from app.db import models
+from app.user import User as UserInfo
+
+
+async def create_user(email: str, info: UserInfo) -> models.User:
+    """Create a new user in the database."""
+    user = await models.User.create(email=email, info=info.model_dump())
+    return user
+
+
+async def get_user_by_email(email: str) -> Optional[models.User]:
+    """Retrieve a user by email address."""
+    try:
+        return await models.User.get(email=email)
+    except DoesNotExist:
+        return None
+
+
+async def update_user_profile(user_id: UUID, info: UserInfo) -> Optional[models.User]:
+    """Update the JSON profile for a user."""
+    try:
+        user = await models.User.get(id=user_id)
+    except DoesNotExist:
+        return None
+
+    user.info = info.model_dump()
+    await user.save()
+    return user

--- a/app/db/workout.py
+++ b/app/db/workout.py
@@ -1,0 +1,38 @@
+from uuid import UUID
+from typing import Optional
+
+from tortoise.exceptions import DoesNotExist
+
+from app.db import models
+from app.workout import WorkoutWeek
+
+
+async def create_workout_chunk(
+    user_id: UUID, workouts: WorkoutWeek
+) -> models.WorkoutChunk:
+    """Create a new workout chunk for a user."""
+    chunk = await models.WorkoutChunk.create(
+        user_id=user_id, workouts=workouts.model_dump()
+    )
+    return chunk
+
+
+async def get_workout_chunk(chunk_id: UUID) -> Optional[models.WorkoutChunk]:
+    """Retrieve a workout chunk by its ID."""
+    try:
+        return await models.WorkoutChunk.get(id=chunk_id)
+    except DoesNotExist:
+        return None
+
+
+async def update_workout_chunk(
+    chunk_id: UUID, workouts: WorkoutWeek
+) -> Optional[models.WorkoutChunk]:
+    """Update the workouts JSON for a chunk."""
+    chunk = await get_workout_chunk(chunk_id)
+    if not chunk:
+        return None
+
+    chunk.workouts = workouts.model_dump()
+    await chunk.save()
+    return chunk


### PR DESCRIPTION
## Summary
- add db helper functions to create and update users
- create helpers for workout chunks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687023cbaf088330a34e7a4d06a007ca