### PR TITLE
Enable deleting exercises via swipe

### DIFF
--- a/groove/groove/Views/Workout/ExerciseRow.swift
+++ b/groove/groove/Views/Workout/ExerciseRow.swift
@@ -10,6 +10,7 @@ import SwiftUI
 
 struct ExerciseRow: View {
     @Binding var exercise: Exercise
+    var onDelete: () -> Void = {}
     
     private let exertionLevels = ["Easy": Color.blue,
                                   "Medium": Color.orange,
@@ -104,16 +105,13 @@ struct ExerciseRow: View {
             }
         }
         .swipeActions(edge: .leading, allowsFullSwipe: false) {
-            Button {
+            Button(role: .destructive) {
                 withAnimation {
-                    // This should delete the set from the workout 
+                    onDelete()
                 }
             } label: {
-                
-                Label("Delete Set", systemImage: "trash").tint(.red)
+                Label("Delete Set", systemImage: "trash")
             }
-            .tint(.gray)
-            
         }
     }
     

--- a/groove/groove/Views/Workout/WorkoutView.swift
+++ b/groove/groove/Views/Workout/WorkoutView.swift
@@ -5,8 +5,10 @@ struct WorkoutView: View {
 
     var body: some View {
         List {
-            ForEach($workout.workout) { $exercise in
-                ExerciseRow(exercise: $exercise)
+            ForEach(workout.workout.indices, id: \.self) { idx in
+                ExerciseRow(exercise: $workout.workout[idx]) {
+                    workout.workout.remove(at: idx)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- support deletion callbacks in `ExerciseRow`
- change `WorkoutView` to supply delete closure using indices

## Testing
- `git diff --cached`


------
https://chatgpt.com/codex/tasks/task_e_688d1fd5ddf083309b32f3c2f150b620