### PR TITLE
Add landing navigation in SwiftUI app

### DIFF
--- a/groove/groove/Views/ContentView.swift
+++ b/groove/groove/Views/ContentView.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+struct ContentView: View {
+    @StateObject private var model = ModelData()
+    @State private var selection: Tab = .home
+
+    enum Tab {
+        case home
+        case current
+    }
+
+    var body: some View {
+        NavigationStack {
+            TabView(selection: $selection) {
+                WorkoutsListView()
+                    .tag(Tab.home)
+                    .tabItem { Label("Home", systemImage: "house") }
+
+                CurrentWorkoutView()
+                    .tag(Tab.current)
+                    .tabItem { Label("Workout", systemImage: "dumbbell") }
+            }
+            .toolbar {
+                NavigationLink(destination: Profile()) {
+                    Image(systemName: "person.crop.circle")
+                }
+            }
+            .navigationTitle("Groove")
+        }
+        .environmentObject(model)
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/groove/groove/Views/Profile/Profile.swift
+++ b/groove/groove/Views/Profile/Profile.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct Profile: View {
-    @StateObject private var model = ModelData()
+    @EnvironmentObject var model: ModelData
     
     var body: some View {
         Text(model.profile.name)
@@ -16,5 +16,5 @@ struct Profile: View {
 }
 
 #Preview {
-    Profile()
+    Profile().environmentObject(ModelData())
 }

--- a/groove/groove/Views/Workout/CurrentWorkoutView.swift
+++ b/groove/groove/Views/Workout/CurrentWorkoutView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct CurrentWorkoutView: View {
+    @EnvironmentObject var model: ModelData
+
+    var body: some View {
+        if let index = model.workouts.indices.first {
+            WorkoutView(workout: $model.workouts[index])
+        } else {
+            Text("No Workouts")
+        }
+    }
+}
+
+#Preview {
+    CurrentWorkoutView().environmentObject(ModelData())
+}

--- a/groove/groove/Views/WorkoutsListView.swift
+++ b/groove/groove/Views/WorkoutsListView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct WorkoutsListView: View {
-    @StateObject private var model = ModelData()
+    @EnvironmentObject var model: ModelData
 
     var body: some View {
         List {
@@ -15,5 +15,5 @@ struct WorkoutsListView: View {
 }
 
 #Preview {
-    WorkoutsListView()
+    WorkoutsListView().environmentObject(ModelData())
 }

--- a/groove/groove/grooveApp.swift
+++ b/groove/groove/grooveApp.swift
@@ -1,15 +1,5 @@
 import SwiftUI
 
-struct ContentView: View {
-    var body: some View {
-        WorkoutsListView()
-    }
-}
-
-#Preview {
-    ContentView()
-}
-
 @main
 struct grooveApp: App {
     var body: some Scene {


### PR DESCRIPTION
## Summary
- centralize model data in `ContentView` as an environment object
- add navigation tabs for home and current workout
- add a profile button in the navigation bar
- update `WorkoutsListView` and `Profile` to read from the shared model
- provide `CurrentWorkoutView` helper

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688d25d61e7c8330ac7440f801c8b492